### PR TITLE
update to use new container names

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,83 +1,45 @@
 version: '3.8'
 
 services:
-  etcd:
-    container_name: milvus-etcd
-    image: quay.io/coreos/etcd:v3.5.5
-    environment:
-      - ETCD_AUTO_COMPACTION_MODE=revision
-      - ETCD_AUTO_COMPACTION_RETENTION=1000
-      - ETCD_QUOTA_BACKEND_BYTES=4294967296
-      - ETCD_SNAPSHOT_COUNT=50000
-    volumes:
-      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/etcd:/etcd
-    command: etcd -advertise-client-urls=http://127.0.0.1:2379 -listen-client-urls http://0.0.0.0:2379 --data-dir /etcd
-    healthcheck:
-      test: ["CMD", "etcdctl", "endpoint", "health"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
-    networks:
-      - rubra
-
-  minio:
-    container_name: milvus-minio
-    image: minio/minio:RELEASE.2023-03-20T20-16-18Z
-    environment:
-      MINIO_ACCESS_KEY: minioadmin
-      MINIO_SECRET_KEY: minioadmin
-    ports:
-      - "9001:9001"
-      - "9000:9000"
-    volumes:
-      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/minio:/minio_data
-    command: minio server /minio_data --console-address ":9001"
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
-    networks:
-      - rubra
-
   standalone:
     container_name: milvus
     image: milvusdb/milvus:v2.3.3
-    command: ["milvus", "run", "standalone"]
+    command: ['milvus', 'run', 'standalone']
     security_opt:
       - seccomp:unconfined
     environment:
-      ETCD_ENDPOINTS: etcd:2379
-      MINIO_ADDRESS: minio:9000
+      ETCD_USE_EMBED: 'true'
+      ETCD_DATA_DIR: '/etcd'
+      ETCD_CONFIG_PATH: '/milvus/configs/embedEtcd.yaml'
+      COMMON_STORAGETYPE: 'local'
     volumes:
-      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/milvus:/var/lib/milvus
+      - milvus:/var/lib/milvus
+      - etcd:/etcd
+      - ${DOCKER_VOLUME_DIRECTORY:-.}/embedEtcd.yaml:/milvus/configs/embedEtcd.yaml
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9091/healthz"]
+      test: ['CMD', 'curl', '-f', 'http://localhost:9091/healthz']
       interval: 30s
       start_period: 90s
       timeout: 20s
       retries: 3
     ports:
-      - "19530:19530"
-      - "9091:9091"
-    depends_on:
-      - "etcd"
-      - "minio"
+      - '19530:19530'
+      - '9091:9091'
     networks:
       - rubra
     logging:
       driver: json-file
       options:
-        max-size: "10m"
-        max-file: "3"
+        max-size: '10m'
+        max-file: '3'
 
   mongodb:
     image: mongo
     container_name: mongodb
     ports:
-      - "27017:27017"
+      - '27017:27017'
     volumes:
-      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/mongodb:/data/db
+      - mongodb:/data/db
     networks:
       - rubra
 
@@ -86,60 +48,61 @@ services:
     container_name: redis
     command: redis-server --appendonly yes
     ports:
-      - "6379:6379"
+      - '6379:6379'
     networks:
       - rubra
 
   litellm:
-    image: ghcr.io/berriai/litellm:main-v1.18.9
+    image: ghcr.io/berriai/litellm:main-v1.22.9
     ports:
-      - "8002:8002"
+      - '8002:8002'
+    container_name: litellm
     volumes:
       - ./llm-config.yaml:/app/config.yaml
     command: ["--config", "/app/config.yaml", "--port", "8002", "--num_workers", "8"]
     networks:
       - rubra
 
-  embedding_model:
+  text-embedding-api:
     build: 
-      context: ./backend/app/embedding_model
+      context: ./services/backend/text_embedding_api
       dockerfile: Dockerfile
-    container_name: embedding_model
-    image: ghcr.io/rubra-ai/embedding_model:latest
+    container_name: text-embedding-api
+    image: ghcr.io/acorn-io/rubra/text_embedding_api:${RUBRA_TAG:-main}
     ports:
-      - "8020:8020"
+      - '8020:8020'
     environment:
       - MODEL_NAME=sentence-transformers/all-MiniLM-L6-v2
     networks:
       - rubra
 
-  vector_db:
+  vector-db-api:
     build: 
-      context: ./backend/app/vector_db
+      context: ./services/backend/vector_db_api
       dockerfile: Dockerfile
-    container_name: vector_db
-    image: ghcr.io/rubra-ai/vector_db:latest
+    container_name: vector-db-api
+    image: ghcr.io/acorn-io/rubra/vector_db_api:${RUBRA_TAG:-main}
     ports:
-      - "8010:8010"
+      - '8010:8010'
     environment:
       - MILVUS_HOST=milvus
-      - EMBEDDING_HOST=embedding_model
+      - EMBEDDING_HOST=text-embedding-api
     networks:
       - rubra
 
 
-  rubra_task_executor:
+  task-executor:
     build: 
-      context: ./backend
+      context: ./services/backend/task_executor
       dockerfile: Dockerfile_task_executor
-    image: ghcr.io/rubra-ai/rubra_task_executor:latest
-    container_name: rubra_task_executor
+    image: ghcr.io/acorn-io/rubra/task_executor:${RUBRA_TAG:-main}
+    container_name: task-executor
     environment:
       - REDIS_HOST=redis
       - MONGODB_HOST=mongodb
       - LITELLM_HOST=litellm
-      - EMBEDDING_HOST=embedding_model
-      - VECTOR_DB_HOST=vector_db
+      - EMBEDDING_HOST=text-embedding-api
+      - VECTOR_DB_HOST=vector-db-api
       - MILVUS_HOST=milvus
     depends_on:
       - redis
@@ -148,39 +111,46 @@ services:
       - rubra
 
 
-  rubra_backend:
+  api-server:
     build: 
-      context: ./backend
+      context: ./services/backend/api_server
       dockerfile: Dockerfile_backend
-    image: ghcr.io/rubra-ai/rubra_backend:latest
-    # image: rubra_backend:latest
-    container_name: rubra_backend
+    image: ghcr.io/acorn-io/rubra/api_server:${RUBRA_TAG:-main}
+    container_name: api-server
     environment:
       - REDIS_HOST=redis
       - MONGODB_HOST=mongodb
       - LITELLM_HOST=litellm
     ports:
-      - "8000:8000"
+      - '8000:8000'
     depends_on:
-      - rubra_task_executor
+      - litellm
+      - task-executor
     networks:
       - rubra
 
-  rubra_frontend:
+  ui:
     build: 
-      context: ./frontend
+      context: ./services/frontend/ui
       dockerfile: Dockerfile
-    image: ghcr.io/rubra-ai/rubra_frontend:latest
-    container_name: rubra_frontend
+    image: ghcr.io/acorn-io/rubra/ui:${RUBRA_TAG:-main}
+    container_name: ui 
     environment:
-      - RUBRA_BACKEND_HOST=rubra_backend
-      - LITELLM_HOST=litellm
+      - RUBRA_BACKEND_HOST=api-server
     ports:
       - "8501:8501"
+    depends_on:
+      - api-server
     networks:
       - rubra
-  
+
 networks:
   rubra:
     name: rubra
     driver: bridge
+
+
+volumes:
+  milvus:
+  mongodb:
+  etcd:

--- a/embedEtcd.yaml
+++ b/embedEtcd.yaml
@@ -1,0 +1,2 @@
+listen-client-urls: http://0.0.0.0:2379
+advertise-client-urls: http://0.0.0.0:2379


### PR DESCRIPTION
Updated to use new container image names from ci.
Default to main, but allow overriding with ENVVAR RUBRA_TAG. switch to named volumes.